### PR TITLE
fix: segfault when linking lwnode as shared library

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        profile: [ release ]
+        config: [ '', '--nopt --shared' ]
     steps:
       - name: Checkout source
         uses: actions/checkout@v2
@@ -27,7 +27,7 @@ jobs:
           sudo apt install -y ninja-build gcc-multilib g++-multilib sed clang-format-8
       - name: Build lwnode
         run: |
-          ./configure.py
+          ./configure.py ${{ matrix.config }}
           ninja -C out/linux/Release lwnode
       - name: Run node.js TCs (test.py)
         run: |

--- a/src/api-data.cc
+++ b/src/api-data.cc
@@ -489,6 +489,7 @@ void v8::WasmModuleObject::CheckCast(Value* that) {
 
 v8::BackingStore::~BackingStore() {
   auto lwIsolate = IsolateWrap::GetCurrent();
+  LWNODE_CHECK(lwIsolate != nullptr);
   lwIsolate->removeBackingStore(reinterpret_cast<BackingStoreRef*>(this));
 }
 


### PR DESCRIPTION
This fixes the segfault occurring when linking `lwnode.so`.

```console
./configure.py --nopt --shared        
ninja -C out/linux/Release lwnode 
```

Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com