### PR TITLE
feat: bind `ReallocArrayBuffer` handler

### DIFF
--- a/src/api/engine.cc
+++ b/src/api/engine.cc
@@ -58,6 +58,12 @@ void Platform::onFreeArrayBufferObjectDataBuffer(void* buffer,
   return allocator_->Free(buffer, sizeInByte);
 }
 
+void* Platform::onReallocArrayBufferObjectDataBuffer(void* oldBuffer,
+                                                     size_t oldSizeInByte,
+                                                     size_t newSizeInByte) {
+  return allocator_->Reallocate(oldBuffer, oldSizeInByte, newSizeInByte);
+}
+
 PlatformRef::LoadModuleResult Platform::onLoadModule(
     ContextRef* relatedContext,
     ScriptRef* whereRequestFrom,

--- a/src/api/engine.h
+++ b/src/api/engine.h
@@ -37,6 +37,9 @@ class Platform : public PlatformRef {
   void* onMallocArrayBufferObjectDataBuffer(size_t sizeInByte) override;
   void onFreeArrayBufferObjectDataBuffer(void* buffer,
                                          size_t sizeInByte) override;
+  void* onReallocArrayBufferObjectDataBuffer(void* oldBuffer,
+                                             size_t oldSizeInByte,
+                                             size_t newSizeInByte) override;
 
   LoadModuleResult onLoadModule(ContextRef* relatedContext,
                                 ScriptRef* whereRequestFrom,


### PR DESCRIPTION
This binds Escargot's `ReallocArrayBuffer` handler
with the `lwnode` internal allocator.

Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com