### PR TITLE
 chore: update release_filter.txt

### DIFF
--- a/tools/release_filter.txt
+++ b/tools/release_filter.txt
@@ -1,7 +1,6 @@
 P /.git
 P /.github
 
-- /tools
 - /sample
 - /deps/node/test
 


### PR DESCRIPTION
The CI step `Building packages` requires `tools/build-modules.sh`.

Signed-off-by: Daeyeon Jeong daeyeon.jeong@samsung.com