### PR TITLE
fix: suppress build errors on gcc 13

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -126,7 +126,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '2.7'
+          python-version: '3.10'
       - name: Install Packages
         run: |
           sudo add-apt-repository "deb http://mirrors.kernel.org/ubuntu/ focal main universe"

--- a/src/api/utils/logger/logger-util.h
+++ b/src/api/utils/logger/logger-util.h
@@ -16,8 +16,10 @@
 
 #include <string>
 
+#ifndef __FILE_NAME__
 #define __FILE_NAME__                                                          \
   (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
 
 #define __FUNCTION_NAME__ getPrettyFunctionName(__PRETTY_FUNCTION__)
 

--- a/tools/check_tidy.py
+++ b/tools/check_tidy.py
@@ -16,8 +16,6 @@
 
 # note: this uses `black` for formatting.
 
-from __future__ import print_function
-
 import os
 import subprocess
 import sys
@@ -96,7 +94,9 @@ def check_tidy(src_dir, update, base, stats):
 
             with open(file, "r") as f:
                 original = f.readlines()
-            formatted = subprocess.check_output([clang_format, "-style=file", file])
+            formatted = subprocess.check_output(
+                [clang_format, "-style=file", file], encoding="utf-8"
+            )
 
             if update:
                 with open(file, "w") as f:


### PR DESCRIPTION
This includes:

- Fix build errors on compilers supporting `__FILE_NAME__` as a builtin macro.
- Fix for the [lint action error](https://github.com/Samsung/lwnode/actions/runs/5531335420/jobs/10091885960).

Signed-off-by: Daeyeon Jeong <daeyeon.jeong@samsung.com>
