### PR TITLE
[Backport] chore: fix gcc 13 build errors

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -2,7 +2,7 @@ name: lwnode actions
 on: [ push, pull_request ]
 jobs:
   build_lwnode:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -40,7 +40,7 @@ jobs:
             test/parallel test/regression
           popd
   cctest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:
       - name: Checkout source
@@ -117,7 +117,7 @@ jobs:
           name: tizen_std_${{ matrix.profile }}
           path: /home/runner/GBS-ROOT/${{ matrix.profile }}/local/repos/${{ matrix.profile }}/armv7l/RPMS/
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -129,9 +129,8 @@ jobs:
           python-version: '3.10'
       - name: Install Packages
         run: |
-          sudo add-apt-repository "deb http://mirrors.kernel.org/ubuntu/ focal main universe"
-          sudo apt-get update
-          sudo apt-get install -y clang-format-8
+          sudo apt update
+          sudo apt install -y ninja-build gcc-multilib g++-multilib sed clang-format-8
       - name: Lint CC
         run: |
           tools/check_tidy.py --filter=$(paste -sd, tools/lint-filters.txt)

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -126,7 +126,7 @@ jobs:
         uses: actions/checkout@v3
       - uses: actions/setup-python@v4
         with:
-          python-version: '2.7'
+          python-version: '3.10'
       - name: Install Packages
         run: |
           sudo add-apt-repository "deb http://mirrors.kernel.org/ubuntu/ focal main universe"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -2,7 +2,7 @@ name: lwnode actions
 on: [ push, pull_request ]
 jobs:
   build_lwnode:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -40,7 +40,7 @@ jobs:
             test/parallel test/regression
           popd
   cctest:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
       - name: Checkout source
@@ -117,7 +117,7 @@ jobs:
           name: tizen_std_${{ matrix.profile }}
           path: /home/runner/GBS-ROOT/${{ matrix.profile }}/local/repos/${{ matrix.profile }}/armv7l/RPMS/
   lint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -129,8 +129,9 @@ jobs:
           python-version: '2.7'
       - name: Install Packages
         run: |
-          sudo apt update
-          sudo apt install -y ninja-build gcc-multilib g++-multilib sed clang-format-8
+          sudo add-apt-repository "deb http://mirrors.kernel.org/ubuntu/ focal main universe"
+          sudo apt-get update
+          sudo apt-get install -y clang-format-8
       - name: Lint CC
         run: |
           tools/check_tidy.py --filter=$(paste -sd, tools/lint-filters.txt)

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -2,7 +2,7 @@ name: lwnode actions
 on: [ push, pull_request ]
 jobs:
   build_lwnode:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     strategy:
       fail-fast: false
@@ -24,7 +24,7 @@ jobs:
       - name: Install Packages
         run: |
           sudo apt update
-          sudo apt install -y ninja-build gcc-multilib g++-multilib sed clang-format-8
+          sudo apt install -y ninja-build gcc-multilib g++-multilib sed
       - name: Build lwnode
         run: |
           ./configure.py ${{ matrix.config }}
@@ -40,7 +40,7 @@ jobs:
             test/parallel test/regression
           popd
   cctest:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     steps:
       - name: Checkout source
@@ -117,17 +117,20 @@ jobs:
           name: tizen_std_${{ matrix.profile }}
           path: /home/runner/GBS-ROOT/${{ matrix.profile }}/local/repos/${{ matrix.profile }}/armv7l/RPMS/
   lint:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     timeout-minutes: 30
     strategy:
       fail-fast: false
     steps:
       - name: Checkout source
         uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '2.7'
       - name: Install Packages
         run: |
           sudo apt update
           sudo apt install -y ninja-build gcc-multilib g++-multilib sed clang-format-8
       - name: Lint CC
         run: |
-          python2 ./tools/check_tidy.py --filter=$(paste -sd, tools/lint-filters.txt)
+          tools/check_tidy.py --filter=$(paste -sd, tools/lint-filters.txt)

--- a/src/api-exception.cc
+++ b/src/api-exception.cc
@@ -82,18 +82,16 @@ v8::TryCatch::~TryCatch() {
 }
 
 void* v8::TryCatch::operator new(size_t) {
-  LWNODE_UNIMPLEMENT;
-  return new TryCatch(nullptr);
+  std::abort();
 }
 void* v8::TryCatch::operator new[](size_t) {
-  LWNODE_UNIMPLEMENT;
-  return new TryCatch(nullptr);
+  std::abort();
 }
 void v8::TryCatch::operator delete(void*, size_t) {
-  LWNODE_UNIMPLEMENT;
+  std::abort();
 }
 void v8::TryCatch::operator delete[](void*, size_t) {
-  LWNODE_UNIMPLEMENT;
+  std::abort();
 }
 
 bool v8::TryCatch::HasCaught() const {

--- a/src/api-handles.cc
+++ b/src/api-handles.cc
@@ -43,13 +43,10 @@ HandleScope::~HandleScope() {
 }
 
 void* HandleScope::operator new(size_t) {
-  LWNODE_UNIMPLEMENT;
-  // TODO: abort : only stack is available
-  return new HandleScope(nullptr);
+  std::abort();
 }
 void* HandleScope::operator new[](size_t) {
-  LWNODE_UNIMPLEMENT;
-  return new HandleScope(nullptr);
+  std::abort();
 }
 void HandleScope::operator delete(void*, size_t) {
   LWNODE_UNIMPLEMENT;
@@ -120,18 +117,16 @@ i::Address* EscapableHandleScope::Escape(i::Address* escape_value) {
 }
 
 void* EscapableHandleScope::operator new(size_t) {
-  LWNODE_UNIMPLEMENT;
-  return new EscapableHandleScope(nullptr);
+  std::abort();
 }
 void* EscapableHandleScope::operator new[](size_t) {
-  LWNODE_UNIMPLEMENT;
-  return new EscapableHandleScope(nullptr);
+  std::abort();
 }
 void EscapableHandleScope::operator delete(void*, size_t) {
-  LWNODE_UNIMPLEMENT;
+  std::abort();
 }
 void EscapableHandleScope::operator delete[](void*, size_t) {
-  LWNODE_UNIMPLEMENT;
+  std::abort();
 }
 
 SealHandleScope::SealHandleScope(Isolate* isolate)
@@ -147,18 +142,16 @@ SealHandleScope::~SealHandleScope() {
 }
 
 void* SealHandleScope::operator new(size_t) {
-  LWNODE_UNIMPLEMENT;
-  return new SealHandleScope(nullptr);
+  std::abort();
 }
 void* SealHandleScope::operator new[](size_t) {
-  LWNODE_UNIMPLEMENT;
-  return new SealHandleScope(nullptr);
+  std::abort();
 }
 void SealHandleScope::operator delete(void*, size_t) {
-  LWNODE_UNIMPLEMENT;
+  std::abort();
 }
 void SealHandleScope::operator delete[](void*, size_t) {
-  LWNODE_UNIMPLEMENT;
+  std::abort();
 }
 
 void Context::Enter() {

--- a/src/api/engine.h
+++ b/src/api/engine.h
@@ -88,7 +88,7 @@ class GCHeap : public gc {
     void* data = nullptr;
   };
   typedef GC_word GC_heap_pointer;
-  typedef std::pair<GC_heap_pointer, AddressInfo> HeapSegment;
+  typedef std::pair<const GC_heap_pointer, AddressInfo> HeapSegment;
 
   void acquire(void* address, Kind kind, void* data);
   void release(void* address, Kind kind);

--- a/src/api/utils/logger/logger-impl.cc
+++ b/src/api/utils/logger/logger-impl.cc
@@ -167,7 +167,7 @@ Logger& Logger::flush() {
 
 void StdOut::flush(std::stringstream& stream,
                    std::shared_ptr<Output::Config> config) {
-  std::cerr << stream.str();
+  fprintf(stderr, "%s", stream.str().c_str());
 }
 
 // --- Option ---

--- a/src/api/utils/logger/logger-util.h
+++ b/src/api/utils/logger/logger-util.h
@@ -16,8 +16,10 @@
 
 #include <string>
 
+#ifndef __FILE_NAME__
 #define __FILE_NAME__                                                          \
   (strrchr(__FILE__, '/') ? strrchr(__FILE__, '/') + 1 : __FILE__)
+#endif
 
 #define __FUNCTION_NAME__ getPrettyFunctionName(__PRETTY_FUNCTION__)
 

--- a/src/api/utils/sf-vector.h
+++ b/src/api/utils/sf-vector.h
@@ -148,7 +148,6 @@ class Vector {
 
   void erase(size_t start, size_t end) {
     if (start == end) return;
-    assert(start >= 0);
     assert(end <= m_size);
 
     size_t howMuch = end - start;
@@ -351,7 +350,6 @@ class Vector {
 
     size_t end = start + sizeToErase;
     assert(start < end);
-    assert(start >= 0);
     assert(end <= m_size);
 
     size_t c = end - start;
@@ -384,7 +382,6 @@ class Vector {
 
     size_t end = start + sizeToErase;
     assert(start < end);
-    assert(start >= 0);
     assert(end <= m_size);
 
     size_t c = end - start;

--- a/tools/check_tidy.py
+++ b/tools/check_tidy.py
@@ -16,8 +16,6 @@
 
 # note: this uses `black` for formatting.
 
-from __future__ import print_function
-
 import os
 import subprocess
 import sys
@@ -96,7 +94,9 @@ def check_tidy(src_dir, update, base, stats):
 
             with open(file, "r") as f:
                 original = f.readlines()
-            formatted = subprocess.check_output([clang_format, "-style=file", file])
+            formatted = subprocess.check_output(
+                [clang_format, "-style=file", file], encoding="utf-8"
+            )
 
             if update:
                 with open(file, "w") as f:

--- a/tools/patch/01-escargot-gcc13-build-error.patch
+++ b/tools/patch/01-escargot-gcc13-build-error.patch
@@ -1,0 +1,12 @@
+diff --git raw/src/api/EscargotPublic.h fix/src/api/EscargotPublic.h
+index 3a8362a9..6fc888d1 100644
+--- raw/src/api/EscargotPublic.h
++++ fix/src/api/EscargotPublic.h
+@@ -30,6 +30,7 @@
+ 
+ #include <cstdlib>
+ #include <cstddef>
++#include <cstdint>
+ #include <cstring>
+ #include <string>
+ #include <vector>

--- a/tools/release.sh
+++ b/tools/release.sh
@@ -23,6 +23,10 @@ git submodule update --init
 pushd deps/escargot
 git submodule update --init third_party
 
+# Patch update code for escargot
+find ../../tools/patch -type f -name "*escargot*.patch" \
+  -exec patch -p1 --forward -r /dev/null -i {} \;
+
 # Patch update code for wasm
 pushd third_party/wasm/wabt
 patch -p0 --forward -r /dev/null -i ../../../tools/test/wasm-js/wabt_patch


### PR DESCRIPTION
Cherry pick the following commits into the `tizen` branch.

* 3a5d0c80d102ba2c5339616a19210cc541ca05da 2023-07-17 Hosung Kim fix: support gcc13
* ca6750686268ca0c3d97ebf532864b623fc03a7c 2023-07-13 Daeyeon Jeong   chore: add patch for escargot gcc 13 build error
* 44904c4d2e4cf9d40c221b1341227e8653ecdf0a 2023-07-12 Daeyeon Jeong   fix: suppress build errors on gcc 13
* b6e04272 2023-07-17 Daeyeon Jeong   chore: fix destination machine on github actions (Newly added)
* 2ded3b33bfa4c62216c777f279cacec5c7be5106 2023-07-12 Daeyeon Jeong   chore: fix lint action
* 5568ba47ec1c813f71f340bf2ff5b8ba5766491e 2023-04-17 HyukWoo Park    fix: fix compiler errors for the latest compiler
* 61521d8c67ab6b227ceac65763cb1f1f5f45297d 2023-04-06 HyukWoo Park    Fix package build error in actions

Signed-off-by: Daeyeon Jeong <daeyeon.jeong@samsung.com>