### PR TITLE
[Backport] fix: fix build break when using openssl3

### DIFF
--- a/deps/node/src/node_crypto.cc
+++ b/deps/node/src/node_crypto.cc
@@ -4579,11 +4579,11 @@ static unsigned int GetBytesOfRS(const ManagedEVPPKey& pkey) {
   int bits, base_id = EVP_PKEY_base_id(pkey.get());
 
   if (base_id == EVP_PKEY_DSA) {
-    DSA* dsa_key = EVP_PKEY_get0_DSA(pkey.get());
+    const DSA* dsa_key = EVP_PKEY_get0_DSA(pkey.get());
     // Both r and s are computed mod q, so their width is limited by that of q.
     bits = BN_num_bits(DSA_get0_q(dsa_key));
   } else if (base_id == EVP_PKEY_EC) {
-    EC_KEY* ec_key = EVP_PKEY_get0_EC_KEY(pkey.get());
+    const EC_KEY* ec_key = EVP_PKEY_get0_EC_KEY(pkey.get());
     const EC_GROUP* ec_group = EC_KEY_get0_group(ec_key);
     bits = EC_GROUP_order_bits(ec_group);
   } else {

--- a/packaging/lwnode.spec
+++ b/packaging/lwnode.spec
@@ -37,14 +37,24 @@ BuildRequires: pkgconfig(glib-2.0)
 BuildRequires: nghttp2-devel
 BuildRequires: pkgconfig(libcares)
 
-%if (0%{?tizen_version_major} >= 6)
+%if (0%{?tizen_version_major} >= 8)
+BuildRequires: pkgconfig(openssl3)
+%endif
+
+%if (0%{?tizen_version_major} == 7 || 0%{?tizen_version_major} == 6)
+BuildRequires: pkgconfig(openssl1.1)
+%endif
+
+%if (0%{?tizen_version_major} == 5)
+%if (0%{?tizen_version_minor} >= 5)
 BuildRequires: pkgconfig(openssl1.1)
 %else
-  %if (0%{?tizen_version_major} == 5) && (0%{?tizen_version_minor} == 5)
-BuildRequires: pkgconfig(openssl1.1)
-  %else
 BuildRequires: pkgconfig(openssl)
-  %endif
+%endif
+%endif
+
+%if (0%{?tizen_version_major} < 5)
+BuildRequires: pkgconfig(openssl)
 %endif
 
 %if 0%{?asan} == 1


### PR DESCRIPTION
Cherry pick the following commits into the `tizen` branch.

- 01f35dd2d2cde245ed327c16d2155e95e752adec fix: fix build break when using openssl3

Signed-off-by: Hosung Kim hs852.kim@samsung.com