### PR TITLE
fix: handle stdio in Tizen

### DIFF
--- a/deps/node/src/lwnode/aul-event-receiver.cc
+++ b/deps/node/src/lwnode/aul-event-receiver.cc
@@ -75,16 +75,17 @@ bool AULEventReceiver::start(int argc, char* argv[]) {
 
   if (hasAulArguments(argc, argv)) {
     isEventReceiverRunning_ = true;
-    initLoggerOutput();
-
-    aul_launch_init(aulEventHandler, nullptr);
-    aul_launch_argv_handler(argc, argv);
 
     char appid[kMaxPackageNameSize + 1];
     aul_app_get_appid_bypid(getpid(), appid, kMaxPackageNameSize);
     appid_ = appid;
 
-    LWNODE_DEV_LOG("appid: ", appid_);
+    initLoggerOutput(appid_);
+
+    LWNODE_DEV_LOG("appid:", appid_);
+
+    aul_launch_init(aulEventHandler, nullptr);
+    aul_launch_argv_handler(argc, argv);
 
     char* path = app_get_resource_path();
     if (uv_chdir(path) != 0) {
@@ -110,9 +111,9 @@ bool AULEventReceiver::isEventReceiverRunning() {
   return isEventReceiverRunning_;
 }
 
-void AULEventReceiver::initLoggerOutput() {
-  if (!appid_.empty()) {
-    LogKind::user()->tag = appid_;
+void AULEventReceiver::initLoggerOutput(const std::string tag) {
+  if (!tag.empty()) {
+    LogKind::user()->tag = tag;
   }
 
   LogOption::setDefaultOutputInstantiator([&]() {

--- a/deps/node/src/lwnode/aul-event-receiver.h
+++ b/deps/node/src/lwnode/aul-event-receiver.h
@@ -37,7 +37,7 @@ class AULEventReceiver {
   }
 #endif
 
-  void initLoggerOutput();
+  void initLoggerOutput(const std::string tag = "");
   bool isEventReceiverRunning();
 
  private:

--- a/src/api/utils/logger/logger.cc
+++ b/src/api/utils/logger/logger.cc
@@ -26,6 +26,9 @@ void DlogOut::flush(std::stringstream& ss,
                     std::shared_ptr<Output::Config> config) {
   auto c =
       config ? std::static_pointer_cast<DLogConfig>(config) : LogKind::lwnode();
+
+  // TODO: handle the case where users manually select a logging method.
+
 #ifdef HOST_TIZEN
   dlog_print(DLOG_INFO, c->tag.c_str(), "%s", ss.str().c_str());
 #else


### PR DESCRIPTION
This hijacks inputs for stdio streams when running on Tizen. That's because stdio is piped to dlog in Tizen apps.

Signed-off-by: Daeyeon Jeong <daeyeon.jeong@samsung.com>