### PR TITLE
fix: remove potential regex_error

### DIFF
--- a/deps/message-port/nd/nd-logger.cc
+++ b/deps/message-port/nd/nd-logger.cc
@@ -119,26 +119,7 @@ void PrintF(const unsigned priority,
 
 std::string GetPrettyFunctionName(const std::string fullname,
                                   std::string prefixPattern) {
-  std::stringstream ss;
-  if (!prefixPattern.empty()) {
-    ss << "(?:" << prefixPattern << ")|";
-  }
-  ss << R"((?::\()|([\w:~]+)\()";
-
-  try {
-    std::smatch match;
-    const std::regex re(ss.str());
-
-    std::stringstream result;
-    std::string suffix = fullname;
-    while (std::regex_search(suffix, match, re)) {
-      result << match[1];
-      suffix = match.suffix();
-    }
-    return result.str();
-  } catch (std::regex_error& e) {
-    return "";
-  }
+  return fullname;
 }
 
 std::string CreateCodeLocation(const char* functionName,

--- a/src/api.cc
+++ b/src/api.cc
@@ -172,6 +172,13 @@ void V8::SetFlagsFromCommandLine(int* argc, char** argv, bool remove_flags) {
     }
   }
 
+  // LWNODE_TRACE_CALL
+  const char* trace_env = std::getenv("LWNODE_TRACE_CALL");
+  if (trace_env) {
+    std::string trace_arg = "--trace-call=";
+    EscargotShim::Global::flags()->add(trace_arg + std::string(trace_env));
+  }
+
   if (remove_flags) {
     EscargotShim::Global::flags()->shrinkArgumentList(argc, argv);
   }

--- a/src/api/utils/logger/logger-impl.cc
+++ b/src/api/utils/logger/logger-impl.cc
@@ -74,10 +74,8 @@ void LogTYPED::printHeader(std::stringstream& stream) {
 }
 
 LogINTERNAL::LogINTERNAL(Type type) : LogTYPED(type) {
-#if defined(NDEBUG)
   isEnabled_ = EscargotShim::Global::flags()->isOn(
       EscargotShim::Flag::Type::InternalLog);
-#endif
 }
 
 LogTRACE::LogTRACE(std::string id,

--- a/src/api/utils/logger/logger-util.cc
+++ b/src/api/utils/logger/logger-util.cc
@@ -24,17 +24,7 @@
 #include "api/global.h"
 
 std::string getPrettyFunctionName(const std::string fullname) {
-  try {
-    std::smatch match;
-    const std::regex re(R"(([\w\:~]+)\()");
-
-    if (std::regex_search(fullname, match, re) && match.size() > 1) {
-      return match.str(1);
-    }
-    return "";
-  } catch (std::regex_error& e) {
-    return "";
-  }
+  return fullname;
 }
 
 std::string createCodeLocation(const char* functionName,

--- a/src/api/utils/logger/trace.h
+++ b/src/api/utils/logger/trace.h
@@ -18,7 +18,7 @@
 
 #include "logger.h"
 
-#if !defined(NDEBUG)
+#if !defined(NDEBUG) || defined(DEV)
 
 // LWNODE_CALL_TRACE with ID
 #define LWNODE_CALL_TRACE_ID_LOG(id, ...)                                      \


### PR DESCRIPTION
This adds a way to enable tracing logs in release build. (`export CFLAGS="${CFLAGS} -DDEV"; export CXXFLAGS="${CXXFLAGS} -DDEV"`) Plus, it removes code using `std::regex_search` since it sometimes doesn't work correctly.
               
Signed-off-by: Daeyeon Jeong <daeyeon.jeong@samsung.com>
