### PR TITLE
chore: fix the incorrect licensing information

### DIFF
--- a/common.gypi
+++ b/common.gypi
@@ -10,7 +10,7 @@
     'defines': [ 'LWNODE=1' ],
     'cflags!': [ '-Wno-error' ],
     'cflags': [
-      '-Wall', '-Wextra', '-Werror',
+      '-Wall', '-Wextra',
       '-Wno-unused-variable',
       '-Wno-unused-function',
       '-Wno-unused-but-set-variable',
@@ -28,7 +28,7 @@
     },
     'configurations': {
       'Debug': {
-        'cflags': [ '-O0' ],
+        'cflags': [ '-O0', '-Werror' ],
       },
       'Release': {
         'defines': ['NDEBUG'],

--- a/include/lwnode/gc-descriptor.h
+++ b/include/lwnode/gc-descriptor.h
@@ -1,20 +1,17 @@
 /*
- * Copyright (c) 2024-present Samsung Electronics Co., Ltd
+ * Copyright (c) 2025-present Samsung Electronics Co., Ltd
  *
- *  This library is free software; you can redistribute it and/or
- *  modify it under the terms of the GNU Lesser General Public
- *  License as published by the Free Software Foundation; either
- *  version 2.1 of the License, or (at your option) any later version.
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
  *
- *  This library is distributed in the hope that it will be useful,
- *  but WITHOUT ANY WARRANTY; without even the implied warranty of
- *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
- *  Lesser General Public License for more details.
+ *     http://www.apache.org/licenses/LICENSE-2.0
  *
- *  You should have received a copy of the GNU Lesser General Public
- *  License along with this library; if not, write to the Free Software
- *  Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301
- *  USA
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
  */
 
 #ifndef __GCDescriptor__


### PR DESCRIPTION
This pr also includes a build config patch as a precaution for svace checks.

Signed-off-by: Daeyeon Jeong <daeyeon.jeong@samsung.com>