### PR TITLE
fix: fix hanging event loop on errors using message port

### DIFF
--- a/deps/node/src/env-inl.h
+++ b/deps/node/src/env-inl.h
@@ -790,6 +790,8 @@ inline bool Environment::can_call_into_js() const {
 }
 
 inline void Environment::set_can_call_into_js(bool can_call_into_js) {
+  // @lwnode
+  LWNode::SetCanCallIntoJS(can_call_into_js);
   can_call_into_js_ = can_call_into_js;
 }
 

--- a/include/lwnode/lwnode.h
+++ b/include/lwnode/lwnode.h
@@ -52,6 +52,9 @@ void InitMainMessagePort(v8::Local<v8::Context> context,
                          LoopHolderUV* loop_holder,
                          uv_loop_t* loop);
 
+bool CanCallIntoJs();
+void SetCanCallIntoJS(bool can_call_into_js);
+
 void IdleGC(v8::Isolate* isolate = nullptr);
 void initDebugger();
 bool dumpSelfMemorySnapshot();

--- a/src/lwnode/lwnode.cc
+++ b/src/lwnode/lwnode.cc
@@ -283,6 +283,17 @@ void InitMainMessagePort(Local<Context> context,
   lwContext->SetAlignedPointerInEmbedderData(kLoopHolder, loop_holder);
 }
 
+// FIXME: Move to a better place (e.g. context or isolate)
+thread_local static bool s_can_call_into_js{true};
+
+bool CanCallIntoJs() {
+  return s_can_call_into_js;
+}
+
+void SetCanCallIntoJS(bool can_call_into_js) {
+  s_can_call_into_js = can_call_into_js;
+}
+
 void InitializeProcessMethods(Local<Object> target, Local<Context> context) {
   auto esContext = CVAL(*context)->context()->get();
   auto esTarget = CVAL(*target)->value()->asObject();

--- a/src/lwnode/nd-mod-message-port.cc
+++ b/src/lwnode/nd-mod-message-port.cc
@@ -222,6 +222,12 @@ class MessagePortWrap : public BaseObject {
         return;
       }
 
+#if defined(LWNODE)
+      if (LWNode::CanCallIntoJs() == false) {
+        return;
+      }
+#endif
+
       ExecResult result =
           Eval::execute(context, [this, event](ExecutionStateRef* state) {
             ObjectRef* event_object = InstantiateMessageEvent(state, event);

--- a/test/embedding/embedtest.cc
+++ b/test/embedding/embedtest.cc
@@ -142,3 +142,38 @@ TEST0(Embedtest, RestartAfterStop) {
     std::cout << count << " /Thread " << std::endl;
   }
 }
+
+TEST(Embedtest, MessagePortErrorAfterRegisterOnMessage, 5000) {
+  auto runtime = std::make_shared<lwnode::Runtime>();
+
+  std::promise<void> promise;
+  std::future<void> init_future = promise.get_future();
+  const char* script = "test/embedding/test-04-message-port-error.js";
+  std::string path = (std::filesystem::current_path() / script).string();
+
+  const bool post_first = true;
+  char* args[] = {const_cast<char*>(""),
+                  const_cast<char*>(path.c_str()),
+                  const_cast<char*>(std::to_string(post_first).c_str())};
+
+  std::thread worker = std::thread(
+      [&](std::promise<void>&& promise) mutable {
+        runtime->Start(COUNT_OF(args), args, std::move(promise));
+      },
+      std::move(promise));
+
+  init_future.wait();
+
+  int count1 = 0;
+
+  auto port2 = runtime->GetPort();
+
+  port2->OnMessage([&](const MessageEvent* event) {
+    std::cout << event->data() << std::endl;
+    count1++;
+  });
+  port2->PostMessage(MessageEvent::New("ping"));
+
+  // This test should not exit due to timeout
+  worker.join();
+}

--- a/test/embedding/test-04-message-port-error.js
+++ b/test/embedding/test-04-message-port-error.js
@@ -1,0 +1,13 @@
+const lwnode = process.lwnode;
+const port = process.lwnode.port;
+
+lwnode.ref();
+
+port.onmessage = (event) => {
+  if (event.data == "ping") {
+    port.postMessage("pong");
+    lwnode.unref();
+  }
+};
+
+error


### PR DESCRIPTION
This resolves an issue where the loop does not exit when an error occurs in the script after the `onmessage` of message port is registered.

Signed-off-by: Daeyeon Jeong <daeyeon.jeong@samsung.com>