### PR TITLE
Change build scripts after move bdwgc files to gcutil repository root

### DIFF
--- a/escargot.gyp
+++ b/escargot.gyp
@@ -77,8 +77,7 @@
       'cflags': [ '-pthread' ],
       'ldflags': [ '-pthread' ],
       'include_dirs': [
-        '<(escargot_dir)/third_party/GCutil',
-        '<(escargot_dir)/third_party/GCutil/bdwgc/include',
+        '<(escargot_dir)/third_party/GCutil/include',
       ],
       'configurations': {
         'Debug': {

--- a/modules/packages/device-api/CMakeLists.txt
+++ b/modules/packages/device-api/CMakeLists.txt
@@ -13,8 +13,7 @@ include_directories(${LWNODE_INCLUDES})
 file (GLOB_RECURSE SOURCE_FILES src/*.cpp)
 include_directories(
   ${PROJECT_ROOT_PATH}/deps/escargot/src/api
-  ${PROJECT_ROOT_PATH}/deps/escargot/third_party/GCutil
-  ${PROJECT_ROOT_PATH}/deps/escargot/third_party/GCutil/bdwgc/include
+  ${PROJECT_ROOT_PATH}/deps/escargot/third_party/GCutil/include
   ${PROJECT_ROOT_PATH}/deps/node/deps/uv/include
   ${PROJECT_ROOT_PATH}/src
   include


### PR DESCRIPTION
This is a follow-up of https://github.com/Samsung/gcutil/pull/34

Remove include directory .../GCutil.
Change include directory .../GCutil/bdwgc/include to .../GCutil/include.